### PR TITLE
Add initial styles for field pair form

### DIFF
--- a/docs/files/templates/modules.jade
+++ b/docs/files/templates/modules.jade
@@ -109,6 +109,18 @@ block content
               ...
             </div>
 
+      h3.tertiary-headline Pair Field Form
+
+      .highlight
+        .form-pair
+          .form-pair__group
+            label(for="test-form-3") Name
+            input(type="text",  name="test-form-3",  id="test-form-3")
+          .form-pair__group
+            label(for="test-form-4") Email
+            input(type="text",  name="test-form-4",  id="test-form-4")
+          button.button(type="submit") Submit
+
     .doc-section
       h2.secondary-headline.doc-headline Lists
 

--- a/source/modules/_forms.scss
+++ b/source/modules/_forms.scss
@@ -29,7 +29,7 @@
 .form-vertical {
   label {
     display: block;
-    margin-bottom: 5px;
+    margin-bottom: em(5px);
   }
 
   input[type="color"],
@@ -50,6 +50,26 @@
   select {
     display: block;
     margin-bottom: $default-whitespace;
+  }
+}
+
+// Field pair form
+
+.form-pair {
+  &__group {
+    margin-bottom: $default-whitespace;
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  label {
+    margin-bottom: em(5px);
+    flex: 0 0 em(120px);
+    margin-right: em(10px);;
+  }
+
+  input {
+    flex: 1 1 em(192px);
   }
 }
 


### PR DESCRIPTION
Allows for side by side labels and inputs in a form, converting to vertical form style on smaller viewports. Achieved by using flexbox so the support is IE10+ as well as Firefox, Safari, and Chrome.
